### PR TITLE
Finalize four-slot hotbar workflow

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -12,6 +12,7 @@
  * - click:left               ({ sx, sy, alt, shift, ctrl }) - clique esquerdo no canvas
  * - click:right              ({ sx, sy, alt, shift, ctrl }) - clique direito no canvas
  * - input:dir                ({ dx, dy }) - vetor de direção normalizado a cada frame
+ * - hotbar:select            ({ slot }) - teclas 1–4 selecionam slots da hotbar
  */
 
 export function setupControls(state, emitter) {
@@ -58,6 +59,8 @@ export function setupControls(state, emitter) {
     return { sx, sy };
   }
 
+  const HOTBAR_KEYS = ["1", "2", "3", "4"];
+
   function onKeyDown(e) {
     const k = toLower(e);
     if (k === "w") keys.w = state.input.w = true;
@@ -70,6 +73,14 @@ export function setupControls(state, emitter) {
     if (k === "c") emitter.emit("action:toggleWallet");
     if (k === "escape") emitter.emit("action:esc");
     if (k === "q") emitter.emit("player:dropHandOne");
+
+    if (HOTBAR_KEYS.includes(k)) {
+      const slotIndex = Number.parseInt(k, 10) - 1;
+      if (Number.isInteger(slotIndex) && slotIndex >= 0) {
+        emitter.emit("hotbar:select", { slot: slotIndex });
+        e.preventDefault();
+      }
+    }
   }
 
   function onKeyUp(e) {

--- a/src/state.js
+++ b/src/state.js
@@ -85,6 +85,29 @@ export function makeInventory(size = 24) {
       return null;
     },
 
+    takeAt(index, qty = 1) {
+      if (qty <= 0) return null;
+      if (!Number.isInteger(index)) return null;
+      if (index < 0 || index >= this.slots.length) return null;
+      const slot = this.slots[index];
+      if (!slot) return null;
+
+      if (slot.meta) {
+        this.slots[index] = null;
+        return { id: slot.id, qty: 1, meta: slot.meta };
+      }
+
+      const take = Math.min(qty, slot.qty);
+      if (take <= 0) return null;
+
+      const item = { id: slot.id, qty: take };
+      slot.qty -= take;
+      if (slot.qty <= 0) {
+        this.slots[index] = null;
+      }
+      return item;
+    },
+
     count(id) {
       if (!id) return 0;
       return this.slots.reduce((sum, slot) => {
@@ -142,6 +165,7 @@ export function initState() {
       dir: "down",
       speed: 210,
       hand: null,
+      hotbar: { size: 4, active: 0 },
       moveDir: { dx: 0, dy: 0 },
       focusId: null,
     },

--- a/styles.css
+++ b/styles.css
@@ -189,52 +189,102 @@ canvas#game.is-blur {
 
 .hotbar__slot {
   position: relative;
-  width: 64px;
-  height: 56px;
+  width: 68px;
+  height: 58px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 6px;
   border-radius: var(--r-md);
   background: rgba(10, 16, 30, 0.58);
   border: 1px solid rgba(148, 163, 184, 0.25);
   color: var(--c-tx-1);
   font-size: 12px;
   text-align: center;
-  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease, transform 0.12s ease;
+  cursor: pointer;
+  padding: 10px 6px 8px;
 }
 
-.hotbar__slot--active {
+.hotbar__slot:hover {
+  border-color: rgba(226, 232, 240, 0.32);
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.hotbar__slot:active {
+  transform: translateY(1px);
+}
+
+.hotbar__slot:focus-visible {
+  outline: 2px solid var(--c-acc-amber);
+  outline-offset: 2px;
+}
+
+.hotbar__slot--selected {
   border-color: var(--c-acc-amber);
   background: rgba(250, 204, 21, 0.16);
   box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.28);
   color: var(--c-tx-0);
 }
 
-.hotbar__key {
-  position: absolute;
-  top: 4px;
-  left: 6px;
-  font-size: 11px;
+.hotbar__slot--empty {
   color: var(--c-tx-dim);
-  opacity: 0.8;
+  opacity: 0.82;
 }
 
-.hotbar__item {
-  font-weight: 600;
-  color: var(--c-tx-0);
-}
-
-.hotbar__item--empty {
+.hotbar__slot--empty .hotbar__label {
   color: var(--c-tx-dim);
   font-style: italic;
   font-weight: 500;
 }
 
-.hotbar__qty {
+.hotbar__slot--cooldown .hotbar__overlay {
+  opacity: 0.75;
+}
+
+.hotbar__key {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  font-size: 11px;
+  color: var(--c-tx-dim);
+  opacity: 0.85;
+}
+
+.hotbar__label {
+  font-weight: 600;
+  color: var(--c-tx-0);
+  line-height: 1.2;
+  max-width: 90%;
+  word-break: break-word;
+}
+
+.hotbar__slot--selected .hotbar__label {
+  color: var(--c-tx-0);
+}
+
+.hotbar__count {
+  position: absolute;
+  bottom: 6px;
+  right: 8px;
   font-size: 11px;
   color: var(--c-tx-1);
+  font-weight: 600;
+}
+
+.hotbar__slot--selected .hotbar__count {
+  color: var(--c-tx-0);
+}
+
+.hotbar__overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(to top, rgba(15, 23, 42, 0.65), transparent);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
 }
 
 /* Pizza de macros (Hunger HUD) */


### PR DESCRIPTION
## Summary
- add slot-based inventory helper and default hotbar state so the player tracks an active hotbar slot
- rework world interactions and events to keep the active hotbar slot, player hand, and hotbar drop/select flows in sync
- refresh the hotbar UI, styling, and controls for the new four-slot layout with mouse and keyboard selection

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cbc5a1ca0483218cbae09aaf3added