### PR TITLE
Add sprint fatigue cooldown and HUD indicator

### DIFF
--- a/src/config/hunger.config.js
+++ b/src/config/hunger.config.js
@@ -34,6 +34,9 @@ export const STAMINA = {
   runLossPerSec: 8,
   regenPerSec: 4,
   minToStartSprint: 3,
+  cooldownDurationSec: 60,
+  significantSprintDrain: 25,
+  sprintDrainDecayPerSec: 6,
 };
 
 export const HUNGER_CONSTANTS = {

--- a/src/world.js
+++ b/src/world.js
@@ -30,6 +30,7 @@ import {
   hasEffect,
   tick as hungerTick,
   getSprintMultiplier,
+  isStaminaOnCooldown,
   applyFood,
 } from "./systems/hunger.js";
 import { STAMINA } from "./config/hunger.config.js";
@@ -516,7 +517,12 @@ function movePlayer(state, dt) {
 
   let running = false;
   const hunger = getHungerState();
-  if ((dir.sprint || state.input?.dir?.sprint) && hunger.stamina >= STAMINA.minToStartSprint) {
+  const wantsSprint = dir.sprint || state.input?.dir?.sprint;
+  if (
+    wantsSprint &&
+    !isStaminaOnCooldown() &&
+    hunger.stamina >= STAMINA.minToStartSprint
+  ) {
     running = true;
     speed *= SPRINT_MULTIPLIER * getSprintMultiplier();
   }

--- a/styles.css
+++ b/styles.css
@@ -330,6 +330,15 @@ canvas#game.is-blur {
   transform: translateY(0);
 }
 
+.hud-hunger--fatigued .hud-hunger__pizza {
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.5),
+    0 0 0 2px rgba(248, 113, 113, 0.45);
+}
+
+.hud-hunger--fatigued .hud-hunger__mask {
+  box-shadow: inset 0 0 0 2px rgba(248, 113, 113, 0.5);
+}
+
 .hud-hunger__badge {
   pointer-events: auto;
   background: rgba(15, 23, 42, 0.88);
@@ -367,6 +376,12 @@ canvas#game.is-blur {
 .hud-hunger__badge.effect-starving {
   background: rgba(220, 38, 38, 0.28);
   border-color: rgba(153, 27, 27, 0.7);
+  color: #fee2e2;
+}
+
+.hud-hunger__badge.effect-fatigue {
+  background: rgba(248, 113, 113, 0.25);
+  border-color: rgba(248, 113, 113, 0.65);
   color: #fee2e2;
 }
 


### PR DESCRIPTION
## Summary
- add a configurable stamina cooldown and fatigue tracking to the hunger system, including sprint drain accumulation and bus events
- prevent sprinting while fatigued and surface the cooldown state via hunger snapshots and HUD updates
- render a fatigue badge/countdown with a HUD highlight and extend the stamina config for cooldown controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbc6e823e08321a4d69c19371fbf23