### PR TITLE
Refactor food labels and hunger parsing

### DIFF
--- a/src/items.js
+++ b/src/items.js
@@ -14,25 +14,25 @@ export const items = {
     name: "Carne",
     maxStack: 100,
     tags: ["food", "noSolid"],
-    meta: { carbs: 0, protein: 14, fat: 10, calories: 120 },
+    labels: ["portion<24>", "carb<0>", "protein<14>", "fat<10>"],
   },
   cookedbeef: {
     name: "Carne Cozida",
     maxStack: 100,
     tags: ["food", "noSolid"],
-    meta: { carbs: 0, protein: 18, fat: 12, calories: 160 },
+    labels: ["portion<30>", "carb<0>", "protein<18>", "fat<12>"],
   },
   berries: {
     name: "Frutas Silvestres",
     maxStack: 100,
     tags: ["food", "noSolid"],
-    meta: { carbs: 18, protein: 2, fat: 1, calories: 60 },
+    labels: ["portion<21>", "carb<18>", "protein<2>", "fat<1>"],
   },
   nuts: {
     name: "Nozes",
     maxStack: 100,
     tags: ["food", "noSolid"],
-    meta: { carbs: 8, protein: 7, fat: 20, calories: 200 },
+    labels: ["portion<35>", "carb<8>", "protein<7>", "fat<20>"],
   },
 
   // Drops de mob


### PR DESCRIPTION
## Summary
- replace food metadata with the new label-based nutrition schema
- parse food labels when consuming items to distribute macros and hunger
- round hunger/macros contributions to hundredth units while respecting clamps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbc7e0baa88321b0629b895196a157